### PR TITLE
BugFix: Logging multiple caught exceptions

### DIFF
--- a/Com.Kumulos.Abstractions/Consts.cs
+++ b/Com.Kumulos.Abstractions/Consts.cs
@@ -2,7 +2,7 @@
 {
     public class Consts
     {
-        public const string SDK_VERSION = "3.0";
+        public const string SDK_VERSION = "3.1";
 
         public const int SDK_TYPE = 7;
 

--- a/Com.Kumulos.Abstractions/Consts.cs
+++ b/Com.Kumulos.Abstractions/Consts.cs
@@ -2,7 +2,7 @@
 {
     public class Consts
     {
-        public const string SDK_VERSION = "3.1";
+        public const string SDK_VERSION = "3.1.2";
 
         public const int SDK_TYPE = 7;
 

--- a/Com.Kumulos.Abstractions/KumulosBaseImplementation.cs
+++ b/Com.Kumulos.Abstractions/KumulosBaseImplementation.cs
@@ -158,26 +158,7 @@ namespace Com.Kumulos.Abstractions
 
         private void TrackCrash(JObject jsonObj)
         {
-            var dict = new Dictionary<string, object>
-            {
-                { "format", (string)jsonObj["format"] },
-                { "uncaught", (bool)jsonObj["uncaught"] }
-            };
-
-            var jsonReportObj = (JContainer)jsonObj["report"];
-
-            var report = new Dictionary<string, object>
-            {
-                { "stackTrace", (string)jsonReportObj["stackTrace"] },
-                { "message", (string)jsonReportObj["message"] },
-                { "type", (string)jsonReportObj["type"] },
-                { "source", (string)jsonReportObj["source"] },
-                { "lineNumber", (int)jsonReportObj["lineNumber"] }
-            };
-
-            dict.Add("report", report);
-
-            TrackEvent(Consts.CRASH_REPORT_EVENT_TYPE, dict);
+            TrackCrashEvent(jsonObj);
         }
 
         private string GetCrashFilePath()
@@ -188,6 +169,8 @@ namespace Com.Kumulos.Abstractions
 
         public abstract void TrackEvent(string eventType, Dictionary<string, object> properties);
 
+        public abstract void TrackCrashEvent(JObject report);
+        
         public abstract string InstallId { get; }
     }
 }

--- a/Com.Kumulos.Abstractions/KumulosBaseImplementation.cs
+++ b/Com.Kumulos.Abstractions/KumulosBaseImplementation.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 
 namespace Com.Kumulos.Abstractions
 {
-    public class Crash
+    abstract public class KumulosBaseImplementation
     {
-        public static Dictionary<string, object> GetDictionaryForExceptionTracking(Exception e, bool uncaught)
+        public Dictionary<string, object> GetDictionaryForExceptionTracking(Exception e, bool uncaught)
         {
             Dictionary<string, object> dict = new Dictionary<string, object>();
 

--- a/Com.Kumulos.Android/KumulosImplementation.cs
+++ b/Com.Kumulos.Android/KumulosImplementation.cs
@@ -31,7 +31,7 @@ namespace Com.Kumulos
         }
     }
 
-    public class KumulosImplementation : IKumulos
+    public class KumulosImplementation :  KumulosBaseImplementation, IKumulos
     {
         public Build Build { get; private set; }
 
@@ -249,7 +249,7 @@ namespace Com.Kumulos
             var frame = st.GetFrame(0);
             var line = frame.GetFileLineNumber();
 
-            var dict = Crash.GetDictionaryForExceptionTracking(e, uncaught);
+            var dict = GetDictionaryForExceptionTracking(e, uncaught);
 
             var report = (Dictionary<string, object>)dict["report"];
             report.Add("lineNumber", line);

--- a/Com.Kumulos.Android/KumulosImplementation.cs
+++ b/Com.Kumulos.Android/KumulosImplementation.cs
@@ -205,15 +205,7 @@ namespace Com.Kumulos
             Android.Kumulos.ClearUserAssociation(Application.Context.ApplicationContext);
         }
 
-        public void LogException(Exception e)
-        {
-            AttemptToLogException(e, false);
-        }
-
-        public void LogUncaughtException(Exception e)
-        {
-            AttemptToLogException(e, true);
-        }
+      
 
         public void SendLocationUpdate(double lat, double lng)
         {
@@ -230,40 +222,7 @@ namespace Com.Kumulos
             Android.Kumulos.TrackEddystoneBeaconProximity(Application.Context.ApplicationContext, namespaceHex, instanceHex, dblDistance);
         }
 
-        private void AttemptToLogException(Exception e, bool uncaught)
-        {
-            try
-            {
-                var dict = GetDictionaryForException(e, uncaught);
-                WriteCrashToDisk(dict);
-            }
-            catch (Exception ex)
-            {
-                //- Don't cause further exceptions trying to log exceptions.
-            }
-        }
-
-        private Dictionary<string, object> GetDictionaryForException(Exception e, bool uncaught)
-        {
-            var st = new StackTrace(e, true);
-            var frame = st.GetFrame(0);
-            var line = frame.GetFileLineNumber();
-
-            var dict = GetDictionaryForExceptionTracking(e, uncaught);
-
-            var report = (Dictionary<string, object>)dict["report"];
-            report.Add("lineNumber", line);
-
-            return dict;
-        }
-
-        private void WriteCrashToDisk(Dictionary<string, object> crash)
-        {
-            var documents = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
-            var filename = Path.Combine(documents, "CrashLog.json");
-            File.WriteAllText(filename, JsonConvert.SerializeObject(crash, Formatting.None));
-        }
-
+      
        
 
         public void TrackiBeaconProximity(object CLBeaconObject)

--- a/Com.Kumulos.Android/KumulosImplementation.cs
+++ b/Com.Kumulos.Android/KumulosImplementation.cs
@@ -201,5 +201,12 @@ namespace Com.Kumulos
         {
             throw new NotImplementedException("This method should not be called on Android");
         }
+
+        public override void TrackCrashEvent(JObject report)
+        {
+            JSONObject javaJson = new JSONObject(JsonConvert.SerializeObject(report, Formatting.None));
+
+            Android.Kumulos.TrackEvent(Application.Context.ApplicationContext, Consts.CRASH_REPORT_EVENT_TYPE, javaJson);
+        }
     }
 }

--- a/Com.Kumulos.Android/KumulosImplementation.cs
+++ b/Com.Kumulos.Android/KumulosImplementation.cs
@@ -176,7 +176,7 @@ namespace Com.Kumulos
             Android.Kumulos.PushUnregister(Application.Context.ApplicationContext);
         }
 
-        public void TrackEvent(string eventType, Dictionary<string, object> properties)
+        public override void TrackEvent(string eventType, Dictionary<string, object> properties)
         {
             JSONObject props = new JSONObject(properties);
             Android.Kumulos.TrackEvent(Application.Context.ApplicationContext, eventType, props);
@@ -264,42 +264,7 @@ namespace Com.Kumulos
             File.WriteAllText(filename, JsonConvert.SerializeObject(crash, Formatting.None));
         }
 
-        private void LogPreviousCrash()
-        {
-            var documents = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
-            var filename = Path.Combine(documents, "CrashLog.json");
-
-            if (!File.Exists(filename))
-            {
-                return;
-            }
-
-            var text = File.ReadAllText(filename);
-            var jsonObj = (JContainer)JsonConvert.DeserializeObject(text);
-
-            var dict = new Dictionary<string, object>
-                {
-                    { "format", (string)jsonObj["format"] },
-                    { "uncaught", (bool)jsonObj["uncaught"] }
-                };
-
-            var reportObj = (JContainer)jsonObj["report"];
-
-            var report = new Dictionary<string, object>
-            {
-                { "stackTrace", (string)reportObj["stackTrace"] },
-                { "message", (string)reportObj["message"] },
-                { "type", (string)reportObj["type"] },
-                { "source", (string)reportObj["source"] },
-                { "lineNumber", (int)reportObj["lineNumber"] }
-            };
-
-            dict.Add("report", report);
-
-            TrackEvent(Consts.CRASH_REPORT_EVENT_TYPE, dict);
-
-            File.Delete(filename);
-        }
+       
 
         public void TrackiBeaconProximity(object CLBeaconObject)
         {

--- a/Com.Kumulos.Android/KumulosImplementation.cs
+++ b/Com.Kumulos.Android/KumulosImplementation.cs
@@ -33,11 +33,7 @@ namespace Com.Kumulos
 
     public class KumulosImplementation :  KumulosBaseImplementation, IKumulos
     {
-        public Build Build { get; private set; }
-
-        public PushChannels PushChannels { get; private set; }
-
-        public void Initialize(IKSConfig config)
+        public override void Initialize(IKSConfig config)
         {
             var androidConfig = (KSConfigImplementation)config;
 
@@ -48,29 +44,10 @@ namespace Com.Kumulos
                 Android.KumulosInApp.SetDeepLinkHandler(new DeepLinkHandlerAbstraction(androidConfig.InAppDeepLinkHandler));
             }
 
-            var httpClient = new HttpClient();
-
-            httpClient.MaxResponseContentBufferSize = 256000;
-
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(
-                System.Text.Encoding.UTF8.GetBytes(string.Format("{0}:{1}", config.GetApiKey(), config.GetSecretKey())
-            )));
-
-
-            Build = new Build(InstallId, httpClient, config.GetApiKey());
-            PushChannels = new PushChannels(InstallId, httpClient);
-
-            try
-            {
-                LogPreviousCrash();
-            }
-            catch (Exception e)
-            {
-                //- Don't cause further exceptions trying to log exceptions.
-            }
+            base.Initialize(config);
         }
 
-        public string InstallId
+        public override string InstallId
         {
             get
             {
@@ -205,8 +182,6 @@ namespace Com.Kumulos
             Android.Kumulos.ClearUserAssociation(Application.Context.ApplicationContext);
         }
 
-      
-
         public void SendLocationUpdate(double lat, double lng)
         {
             Location location = new Location("provider");
@@ -221,10 +196,7 @@ namespace Com.Kumulos
             Java.Lang.Double dblDistance = new Java.Lang.Double(distanceMetres);
             Android.Kumulos.TrackEddystoneBeaconProximity(Application.Context.ApplicationContext, namespaceHex, instanceHex, dblDistance);
         }
-
-      
-       
-
+        
         public void TrackiBeaconProximity(object CLBeaconObject)
         {
             throw new NotImplementedException("This method should not be called on Android");

--- a/Com.Kumulos.iOS/KumulosImplementation.cs
+++ b/Com.Kumulos.iOS/KumulosImplementation.cs
@@ -167,7 +167,7 @@ namespace Com.Kumulos
             iOS.Kumulos_Push.PushUnregister(thisRef);
         }
 
-        public void TrackEvent(string eventType, Dictionary<string, object> properties)
+        public override void TrackEvent(string eventType, Dictionary<string, object> properties)
         {
             var nsDict = ConvertDictionaryToNSDictionary(properties);
 
@@ -253,42 +253,7 @@ namespace Com.Kumulos
             File.WriteAllText(filename, JsonConvert.SerializeObject(crash, Formatting.None));
         }
 
-        private void LogPreviousCrash()
-        {
-            var documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-            var filename = Path.Combine(documents, "CrashLog.json");
-
-            if (!File.Exists(filename))
-            {
-                return;
-            }
-
-            var text = File.ReadAllText(filename);
-            var jsonObj = (JContainer)JsonConvert.DeserializeObject(text);
-
-            var dict = new Dictionary<string, object>
-                {
-                    { "format", (string)jsonObj["format"] },
-                    { "uncaught", (bool)jsonObj["uncaught"] }
-                };
-
-            var reportObj = (JContainer)jsonObj["report"];
-
-            var report = new Dictionary<string, object>
-            {
-                { "stackTrace", (string)reportObj["stackTrace"] },
-                { "message", (string)reportObj["message"] },
-                { "type", (string)reportObj["type"] },
-                { "source", (string)reportObj["source"] },
-                { "lineNumber", (int)reportObj["lineNumber"] }
-            };
-
-            dict.Add("report", report);
-
-            TrackEvent(Consts.CRASH_REPORT_EVENT_TYPE, dict);
-
-            File.Delete(filename);
-        }
+        
 
         private NSDictionary ConvertDictionaryToNSDictionary(Dictionary<string, object> dict)
         {

--- a/Com.Kumulos.iOS/KumulosImplementation.cs
+++ b/Com.Kumulos.iOS/KumulosImplementation.cs
@@ -224,5 +224,29 @@ namespace Com.Kumulos
         {
             throw new NotImplementedException("This method should not be called on iOS");
         }
+
+        public override void TrackCrashEvent(JObject report)
+        {
+            var dict = new Dictionary<string, object>
+            {
+                { "format", (string)report["format"] },
+                { "uncaught", (bool)report["uncaught"] }
+            };
+
+            var nestedReport = (JContainer)report["report"];
+
+            var reportDict = new Dictionary<string, object>
+            {
+                { "stackTrace", (string)nestedReport["stackTrace"] },
+                { "message", (string)nestedReport["message"] },
+                { "type", (string)nestedReport["type"] },
+                { "source", (string)nestedReport["source"] },
+                { "lineNumber", (int)nestedReport["lineNumber"] }
+            };
+
+            dict.Add("report", reportDict);
+
+            TrackEvent(Consts.CRASH_REPORT_EVENT_TYPE, dict);
+        }
     }
 }

--- a/Com.Kumulos.iOS/KumulosImplementation.cs
+++ b/Com.Kumulos.iOS/KumulosImplementation.cs
@@ -179,17 +179,7 @@ namespace Com.Kumulos
 
             iOS.Kumulos_Analytics.TrackEventImmediately(thisRef, eventType, ConvertDictionaryToNSDictionary(properties));
         }
-
-        public void LogException(Exception e)
-        {
-            AttemptToLogException(e, false);
-        }
-
-        public void LogUncaughtException(Exception e)
-        {
-            AttemptToLogException(e, true);
-        }
-
+               
         public void SendLocationUpdate(double lat, double lng)
         {
             CLLocation cl = new CLLocation(lat, lng);
@@ -219,40 +209,7 @@ namespace Com.Kumulos
             iOS.Kumulos_Location.SendiBeaconProximity(thisRef, (CLBeacon)CLBeaconObject);
         }
 
-        private void AttemptToLogException(Exception e, bool uncaught)
-        {
-            try
-            {
-                var dict = GetDictionaryForException(e, uncaught);
-                WriteCrashToDisk(dict);
-            }
-            catch (Exception ex)
-            {
-                // Dont cause
-            }
-        }
-
-        private Dictionary<string, object> GetDictionaryForException(Exception e, bool uncaught)
-        {
-            var st = new StackTrace(e, true);
-            var frame = st.GetFrame(0);
-            var line = frame.GetFileLineNumber();
-
-            var dict = GetDictionaryForExceptionTracking(e, uncaught);
-
-            var report = (Dictionary<string, object>)dict["report"];
-            report.Add("lineNumber", line);
-
-            return dict;
-        }
-
-        private void WriteCrashToDisk(Dictionary<string, object> crash)
-        {
-            var documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-            var filename = Path.Combine(documents, "CrashLog.json");
-            File.WriteAllText(filename, JsonConvert.SerializeObject(crash, Formatting.None));
-        }
-
+        
         
 
         private NSDictionary ConvertDictionaryToNSDictionary(Dictionary<string, object> dict)

--- a/Com.Kumulos.iOS/KumulosImplementation.cs
+++ b/Com.Kumulos.iOS/KumulosImplementation.cs
@@ -15,7 +15,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Com.Kumulos
 {
-    public class KumulosImplementation : IKumulos
+    public class KumulosImplementation : KumulosBaseImplementation, IKumulos
     {
         private iOS.Kumulos thisRef;
 
@@ -238,7 +238,7 @@ namespace Com.Kumulos
             var frame = st.GetFrame(0);
             var line = frame.GetFileLineNumber();
 
-            var dict = Crash.GetDictionaryForExceptionTracking(e, uncaught);
+            var dict = GetDictionaryForExceptionTracking(e, uncaught);
 
             var report = (Dictionary<string, object>)dict["report"];
             report.Add("lineNumber", line);

--- a/Com.Kumulos.iOS/KumulosImplementation.cs
+++ b/Com.Kumulos.iOS/KumulosImplementation.cs
@@ -19,39 +19,16 @@ namespace Com.Kumulos
     {
         private iOS.Kumulos thisRef;
 
-        public Build Build { get; private set; }
-
-        public PushChannels PushChannels { get; private set; }
-
-        public void Initialize(IKSConfig config)
+        public override void Initialize(IKSConfig config)
         {
             var iosKSConfig = (KSConfigImplementation)config;
 
             thisRef = iOS.Kumulos.InitializeWithConfig(iosKSConfig.Build());
 
-            var httpClient = new HttpClient();
-
-            httpClient.MaxResponseContentBufferSize = 256000;
-
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(
-                System.Text.Encoding.UTF8.GetBytes(string.Format("{0}:{1}", config.GetApiKey(), config.GetSecretKey())
-            )));
-
-
-            Build = new Build(InstallId, httpClient, config.GetApiKey());
-            PushChannels = new PushChannels(InstallId, httpClient);
-
-            try
-            {
-                LogPreviousCrash();
-            }
-            catch (Exception e)
-            {
-                //- Don't cause further exceptions trying to log exceptions.
-            }
+            base.Initialize(config);
         }
 
-        public string InstallId
+        public override string InstallId
         {
             get
             {
@@ -208,10 +185,7 @@ namespace Com.Kumulos
         {
             iOS.Kumulos_Location.SendiBeaconProximity(thisRef, (CLBeacon)CLBeaconObject);
         }
-
         
-        
-
         private NSDictionary ConvertDictionaryToNSDictionary(Dictionary<string, object> dict)
         {
             var complexPairs = new List<KeyValuePair<NSObject, NSObject>>();

--- a/Com.Kumulos.nuspec
+++ b/Com.Kumulos.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
     <metadata>
         <id>Com.Kumulos</id>
-        <version>2.0.1.0</version>
+        <version>2.0.1.5</version>
         <title>Kumulos SDK for Xamarin</title>
         <authors>Kumulos Ltd</authors>
         <owners>Kumulos Ltd</owners>

--- a/Com.Kumulos.nuspec
+++ b/Com.Kumulos.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
     <metadata>
         <id>Com.Kumulos</id>
-        <version>2.0.0.23</version>
+        <version>2.0.1.0</version>
         <title>Kumulos SDK for Xamarin</title>
         <authors>Kumulos Ltd</authors>
         <owners>Kumulos Ltd</owners>


### PR DESCRIPTION
Logging multiple caught exceptions in the same session was failing to track as the mono-layer crash handler was expecting to write a Newtonsoft JObject to a file which would then be read off the disk the next time the app was started.

If multiple exceptions were logged during the same session the serializer would write multiple JSON objects to the file with no formatting to separate out the objects. This would then fail to deserialize when the file was read.

Changes:
- Crash implementation has been moved to a shared KumulosBaseImplementation in the Abstractions layer.

- Crashes are now recorded by serializing / deserializing a JArray to disk with 1->N objects, these are then read off and recorded in the next session.