### PR TITLE
Foreground push handler JIT exception

### DIFF
--- a/Com.Kumulos.Abstractions/Consts.cs
+++ b/Com.Kumulos.Abstractions/Consts.cs
@@ -2,7 +2,7 @@
 {
     public class Consts
     {
-        public const string SDK_VERSION = "3.1.3";
+        public const string SDK_VERSION = "4.0.0";
 
         public const int SDK_TYPE = 7;
 

--- a/Com.Kumulos.iOS/KSConfigImplementation.cs
+++ b/Com.Kumulos.iOS/KSConfigImplementation.cs
@@ -2,6 +2,7 @@
 using Com.Kumulos.Abstractions;
 using Foundation;
 using Newtonsoft.Json.Linq;
+using UserNotifications;
 
 namespace Com.Kumulos
 {
@@ -13,6 +14,7 @@ namespace Com.Kumulos
         private InAppConsentStrategy consentStrategy = InAppConsentStrategy.NotEnabled;
         private iOS.KSPushOpenedHandlerBlock pushOpenedHandlerBlock;
         private iOS.KSPushReceivedInForegroundHandlerBlock pushReceivedInForegroundHandlerBlock;
+        private UNNotificationPresentationOptions notificationPresentationOptions;
 
         protected IInAppDeepLinkHandler InAppDeepLinkHandler { get; private set; }
 
@@ -54,6 +56,12 @@ namespace Com.Kumulos
             return this;
         }
 
+        public IKSConfig SetForegroundPushPresentationOptions(UNNotificationPresentationOptions notificationPresentationOptions)
+        {
+            this.notificationPresentationOptions = notificationPresentationOptions;
+            return this;
+        }
+
         public IKSConfig SetPushReceivedInForegroundHandler(iOS.KSPushReceivedInForegroundHandlerBlock pushReceivedInForegroundHandlerBlock)
         {
             this.pushReceivedInForegroundHandlerBlock = pushReceivedInForegroundHandlerBlock;
@@ -83,6 +91,8 @@ namespace Com.Kumulos
             {
                 specificConfig.SetPushOpenedHandler(pushOpenedHandlerBlock);
             }
+
+            specificConfig.SetForegroundPushPresentationOptions(notificationPresentationOptions);
 
             if (pushReceivedInForegroundHandlerBlock != null)
             {

--- a/Com.Kumulos.nuspec
+++ b/Com.Kumulos.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
     <metadata>
         <id>Com.Kumulos</id>
-        <version>2.0.1.6</version>
+        <version>3.0.0.2</version>
         <title>Kumulos SDK for Xamarin</title>
         <authors>Kumulos Ltd</authors>
         <owners>Kumulos Ltd</owners>

--- a/Kumulos.iOS.Binding/ApiDefinition.cs
+++ b/Kumulos.iOS.Binding/ApiDefinition.cs
@@ -21,8 +21,8 @@ namespace Com.Kumulos.iOS
     // typedef void (^ _Nonnull)(UNNotificationPresentationOptions) KSPushReceivedInForegroundCompletionHandler;
     delegate void KSPushReceivedInForegroundCompletionHandler(UNNotificationPresentationOptions arg0);
 
-    // typedef void (^ _Nullable)(KSPushNotification * _Nonnull, KSPushReceivedInForegroundCompletionHandler) KSPushReceivedInForegroundHandlerBlock;
-    delegate void KSPushReceivedInForegroundHandlerBlock(KSPushNotification arg0, KSPushReceivedInForegroundCompletionHandler arg1);
+    // typedef void (^ _Nullable)(KSPushNotification * _Nonnull) KSPushReceivedInForegroundHandlerBlock;
+    delegate void KSPushReceivedInForegroundHandlerBlock(KSPushNotification arg0);
 
     // @interface KSConfig : NSObject
     [BaseType(typeof(NSObject))]
@@ -56,6 +56,11 @@ namespace Com.Kumulos.iOS
         // @property (readonly, nonatomic) KSTargetType targetType;
         [Export("targetType")]
         KSTargetType TargetType { get; }
+
+        // @property (readonly, nonatomic) UNNotificationPresentationOptions foregroundPushPresentationOptions __attribute__((availability(ios, introduced=10.0))) __attribute__((availability(macos, introduced=10.14)));
+        [Mac(10, 14), iOS(10, 0)]
+        [Export("foregroundPushPresentationOptions")]
+        UNNotificationPresentationOptions ForegroundPushPresentationOptions { get; }
 
         // @property (readonly, nonatomic) KSInAppConsentStrategy inAppConsentStrategy;
         [Export("inAppConsentStrategy")]
@@ -100,6 +105,11 @@ namespace Com.Kumulos.iOS
         [Mac(10, 14), iOS(10, 0)]
         [Export("setPushReceivedInForegroundHandler:")]
         KSConfig SetPushReceivedInForegroundHandler([NullAllowed] KSPushReceivedInForegroundHandlerBlock receivedHandler);
+
+        // -(instancetype _Nonnull)setForegroundPushPresentationOptions:(UNNotificationPresentationOptions)notificationPresentationOptions __attribute__((availability(ios, introduced=10.0))) __attribute__((availability(macos, introduced=10.14)));
+        [Mac(10, 14), iOS(10, 0)]
+        [Export("setForegroundPushPresentationOptions:")]
+        KSConfig SetForegroundPushPresentationOptions(UNNotificationPresentationOptions notificationPresentationOptions);
 
         // -(instancetype _Nonnull)setSessionIdleTimeout:(NSUInteger)timeoutSeconds;
         [Export("setSessionIdleTimeout:")]

--- a/Kumulos.iOS.Binding/StructsAndEnums.cs
+++ b/Kumulos.iOS.Binding/StructsAndEnums.cs
@@ -31,7 +31,7 @@ namespace Com.Kumulos.iOS
 	[Native]
 	public enum KSInAppMessagePresentationResult : long
 	{
-		Presented,
+        Presented,
 		Expired,
 		Failed
 	}

--- a/Kumulos.iOS.Binding/StructsAndEnums.cs
+++ b/Kumulos.iOS.Binding/StructsAndEnums.cs
@@ -2,37 +2,37 @@ using ObjCRuntime;
 
 namespace Com.Kumulos.iOS
 {
-    [Native]
-    public enum KSTargetType : long
-    {
-        NotOverridden,
-        Debug,
-        Release
-    }
+	[Native]
+	public enum KSTargetType : long
+	{
+		NotOverridden,
+		Debug,
+		Release
+	}
 
-    [Native]
-    public enum KSInAppConsentStrategy : long
-    {
-        NotEnabled,
-        AutoEnroll,
-        ExplicitByUser
-    }
+	[Native]
+	public enum KSInAppConsentStrategy : long
+	{
+		NotEnabled,
+		AutoEnroll,
+		ExplicitByUser
+	}
 
-    [Native]
-    public enum KSErrorCode : long
-    {
-        NetworkError,
-        RpcError,
-        UnknownError,
-        ValidationError,
-        HttpBadStatus
-    }
+	[Native]
+	public enum KSErrorCode : long
+	{
+		NetworkError,
+		RpcError,
+		UnknownError,
+		ValidationError,
+		HttpBadStatus
+	}
 
-    [Native]
-    public enum KSInAppMessagePresentationResult : long
-    {
-        Presented,
-        Expired,
-        Failed
-    }
+	[Native]
+	public enum KSInAppMessagePresentationResult : long
+	{
+		Presented,
+		Expired,
+		Failed
+	}
 }


### PR DESCRIPTION
Using the foreground push handler could produce runtime exceptions on iOS due to the mono AOT compiler missing code branches and leaving some code in a JIT state. 

To bypass this the `SetPushReceivedInForegroundHandler` no longer provides a reference to the onCompletion handler and instead the SDK can be given a configuration parameter for what presentation options should be used for pushes received while the app is open.