### PR TITLE
Update Build abstractions to use JSON requests

### DIFF
--- a/Com.Kumulos.Abstractions/Build.cs
+++ b/Com.Kumulos.Abstractions/Build.cs
@@ -12,14 +12,12 @@ namespace Com.Kumulos.Abstractions
     {
         private readonly HttpClient httpClient = new HttpClient();
 
-        private readonly string installId;
         private readonly string apiKey;
 
         private string sessionToken = Guid.NewGuid().ToString();
 
-        public Build(string installId, HttpClient httpClient, string apiKey)
+        public Build(HttpClient httpClient, string apiKey)
         {
-            this.installId = installId;
             this.httpClient = httpClient;
             this.apiKey = apiKey;
         }
@@ -59,11 +57,20 @@ namespace Com.Kumulos.Abstractions
 
         HttpContent BuildRequestContent(List<KeyValuePair<string, string>> parameters)
         {
-            var completeParams = new List<KeyValuePair<string, object>>();
-            completeParams.Add(new KeyValuePair<string, object>("sessionToken", sessionToken));
-            completeParams.Add(new KeyValuePair<string, object>("params", parameters));
+            var completeParams = new Dictionary<string, object>();
+            completeParams.Add("sessionToken", sessionToken);
+
+            var parsedParams = new Dictionary<string, string>();
+
+            foreach (KeyValuePair<string, string> pair in parameters)
+            {
+                parsedParams.Add(pair.Key, pair.Value);
+            }
+
+            completeParams.Add("params", parsedParams);
 
             string json = JsonConvert.SerializeObject(completeParams);
+
             return new StringContent(json, Encoding.UTF8, "application/json");
         }
 

--- a/Com.Kumulos.Abstractions/Build.cs
+++ b/Com.Kumulos.Abstractions/Build.cs
@@ -59,7 +59,11 @@ namespace Com.Kumulos.Abstractions
 
         HttpContent BuildRequestContent(List<KeyValuePair<string, string>> parameters)
         {
-            string json = JsonConvert.SerializeObject(parameters);
+            var completeParams = new List<KeyValuePair<string, object>>();
+            completeParams.Add(new KeyValuePair<string, object>("sessionToken", sessionToken));
+            completeParams.Add(new KeyValuePair<string, object>("params", parameters));
+
+            string json = JsonConvert.SerializeObject(completeParams);
             return new StringContent(json, Encoding.UTF8, "application/json");
         }
 

--- a/Com.Kumulos.Abstractions/Build.cs
+++ b/Com.Kumulos.Abstractions/Build.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
+using System.Text;
 
 namespace Com.Kumulos.Abstractions
 {
@@ -41,7 +42,7 @@ namespace Com.Kumulos.Abstractions
         {
             var uri = new Uri(string.Format("{0}/b2.2/{1}/{2}.json", Consts.BUILD_SERVICE_BASE_URI, apiKey, methodName));
 
-            var postContent = BuildRequestParameters(parameters);
+            var postContent = BuildRequestContent(parameters);
 
             HttpResponseMessage request = await httpClient.PostAsync(uri, postContent);
 
@@ -56,24 +57,10 @@ namespace Com.Kumulos.Abstractions
             return null;
         }
 
-        FormUrlEncodedContent BuildRequestParameters(List<KeyValuePair<string, string>> parameters)
+        HttpContent BuildRequestContent(List<KeyValuePair<string, string>> parameters)
         {
-            var postParams = new List<KeyValuePair<string, string>> { };
-
-            foreach (KeyValuePair<string, string> parameter in parameters)
-            {
-                postParams.Add(new KeyValuePair<string, string>("params[" + parameter.Key + "]", parameter.Value));
-            }
-
-            postParams.Add(new KeyValuePair<string, string>("deviceID", installId));
-            postParams.Add(new KeyValuePair<string, string>("installId", installId));
-
-            if (sessionToken != null)
-            {
-                postParams.Add(new KeyValuePair<string, string>("sessionToken", sessionToken));
-            }
-
-            return new FormUrlEncodedContent(postParams);
+            string json = JsonConvert.SerializeObject(parameters);
+            return new StringContent(json, Encoding.UTF8, "application/json");
         }
 
         private void updateSessionToken(JObject response)

--- a/Com.Kumulos.Abstractions/Build.cs
+++ b/Com.Kumulos.Abstractions/Build.cs
@@ -12,12 +12,14 @@ namespace Com.Kumulos.Abstractions
     {
         private readonly HttpClient httpClient = new HttpClient();
 
+        private readonly string installId;
         private readonly string apiKey;
 
         private string sessionToken = Guid.NewGuid().ToString();
 
-        public Build(HttpClient httpClient, string apiKey)
+        public Build(string installId, HttpClient httpClient, string apiKey)
         {
+            this.installId = installId;
             this.httpClient = httpClient;
             this.apiKey = apiKey;
         }
@@ -59,6 +61,8 @@ namespace Com.Kumulos.Abstractions
         {
             var completeParams = new Dictionary<string, object>();
             completeParams.Add("sessionToken", sessionToken);
+            completeParams.Add("deviceID", installId);
+            completeParams.Add("installId", installId);
 
             var parsedParams = new Dictionary<string, string>();
 

--- a/Com.Kumulos.Abstractions/Consts.cs
+++ b/Com.Kumulos.Abstractions/Consts.cs
@@ -2,7 +2,7 @@
 {
     public class Consts
     {
-        public const string SDK_VERSION = "6.1.0";
+        public const string SDK_VERSION = "6.1.1";
 
         public const int SDK_TYPE = 7;
 

--- a/Com.Kumulos.Abstractions/KumulosBaseImplementation.cs
+++ b/Com.Kumulos.Abstractions/KumulosBaseImplementation.cs
@@ -25,8 +25,7 @@ namespace Com.Kumulos.Abstractions
                 System.Text.Encoding.UTF8.GetBytes(string.Format("{0}:{1}", config.GetApiKey(), config.GetSecretKey())
             )));
 
-
-            Build = new Build(httpClient, config.GetApiKey());
+            Build = new Build(InstallId, httpClient, config.GetApiKey());
             PushChannels = new PushChannels(InstallId, httpClient);
 
             LogPreviousCrashes();

--- a/Com.Kumulos.Abstractions/KumulosBaseImplementation.cs
+++ b/Com.Kumulos.Abstractions/KumulosBaseImplementation.cs
@@ -26,7 +26,7 @@ namespace Com.Kumulos.Abstractions
             )));
 
 
-            Build = new Build(InstallId, httpClient, config.GetApiKey());
+            Build = new Build(httpClient, config.GetApiKey());
             PushChannels = new PushChannels(InstallId, httpClient);
 
             LogPreviousCrashes();
@@ -170,7 +170,7 @@ namespace Com.Kumulos.Abstractions
         public abstract void TrackEvent(string eventType, Dictionary<string, object> properties);
 
         public abstract void TrackCrashEvent(JObject report);
-        
+
         public abstract string InstallId { get; }
     }
 }

--- a/Com.Kumulos.Extension.nuspec
+++ b/Com.Kumulos.Extension.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
     <metadata>
         <id>Com.Kumulos.Extension</id>
-        <version>5.1.1.1</version>
+        <version>5.1.1.2</version>
         <title>Kumulos SDK iOS Extensions for Xamarin</title>
         <authors>Kumulos Ltd</authors>
         <owners>Kumulos Ltd</owners>

--- a/Com.Kumulos.Extension.nuspec
+++ b/Com.Kumulos.Extension.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
     <metadata>
         <id>Com.Kumulos.Extension</id>
-        <version>5.1.1.0</version>
+        <version>5.1.1.1</version>
         <title>Kumulos SDK iOS Extensions for Xamarin</title>
         <authors>Kumulos Ltd</authors>
         <owners>Kumulos Ltd</owners>

--- a/Com.Kumulos.Extension.nuspec
+++ b/Com.Kumulos.Extension.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
     <metadata>
         <id>Com.Kumulos.Extension</id>
-        <version>5.1.0.0</version>
+        <version>5.1.1.0</version>
         <title>Kumulos SDK iOS Extensions for Xamarin</title>
         <authors>Kumulos Ltd</authors>
         <owners>Kumulos Ltd</owners>

--- a/Com.Kumulos.nuspec
+++ b/Com.Kumulos.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
     <metadata>
         <id>Com.Kumulos</id>
-        <version>5.1.1.1</version>
+        <version>5.1.1.2</version>
         <title>Kumulos SDK for Xamarin</title>
         <authors>Kumulos Ltd</authors>
         <owners>Kumulos Ltd</owners>

--- a/Com.Kumulos.nuspec
+++ b/Com.Kumulos.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
     <metadata>
         <id>Com.Kumulos</id>
-        <version>5.1.0.0</version>
+        <version>5.1.1.0</version>
         <title>Kumulos SDK for Xamarin</title>
         <authors>Kumulos Ltd</authors>
         <owners>Kumulos Ltd</owners>

--- a/Com.Kumulos.nuspec
+++ b/Com.Kumulos.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
     <metadata>
         <id>Com.Kumulos</id>
-        <version>5.1.1.0</version>
+        <version>5.1.1.1</version>
         <title>Kumulos SDK for Xamarin</title>
         <authors>Kumulos Ltd</authors>
         <owners>Kumulos Ltd</owners>


### PR DESCRIPTION
### Description of Changes

The Build API can accept payloads as JSON which overcomes some limitations with sizes of encoded params, our internal implementation has been updated to use this rather than Form encoding.

### Breaking Changes

- None

### Release Checklist

Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number
- [x] Set Build target to Release -> Rebuild All
- [x] Run `nuget pack` to create a bundle for nuget.org

Bump versions in:

- [x] `Com.Kumulos.nuspec`
- [x] `Com.Kumulos.Extension.nuspec`
- [x] `Com.Kumulos.Abstractions\Consts.cs`

Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create release/tag from master matching chosen version
- [ ] Upload the output Com.Kumulos.[version].nupkg to nuget.org
