### PR TITLE
Use separate HttpClients for interacting with backend services to allow for different configuration

### DIFF
--- a/Com.Kumulos.Abstractions/Consts.cs
+++ b/Com.Kumulos.Abstractions/Consts.cs
@@ -2,7 +2,7 @@
 {
     public class Consts
     {
-        public const string SDK_VERSION = "6.1.1";
+        public const string SDK_VERSION = "6.1.2";
 
         public const int SDK_TYPE = 7;
 

--- a/Com.Kumulos.Abstractions/KumulosBaseImplementation.cs
+++ b/Com.Kumulos.Abstractions/KumulosBaseImplementation.cs
@@ -17,18 +17,26 @@ namespace Com.Kumulos.Abstractions
 
         public virtual void Initialize(IKSConfig config)
         {
+            // 3MB buffer for build
+            Build = new Build(InstallId, configureHttpClient(config, 3145728), config.GetApiKey());
+
+            // 256k for push
+            PushChannels = new PushChannels(InstallId, configureHttpClient(config, 256000));
+
+            LogPreviousCrashes();
+        }
+
+        private HttpClient configureHttpClient(IKSConfig config, long bufferSize)
+        {
             var httpClient = new HttpClient();
 
-            httpClient.MaxResponseContentBufferSize = 256000;
+            httpClient.MaxResponseContentBufferSize = bufferSize;
 
             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(
                 System.Text.Encoding.UTF8.GetBytes(string.Format("{0}:{1}", config.GetApiKey(), config.GetSecretKey())
             )));
 
-            Build = new Build(InstallId, httpClient, config.GetApiKey());
-            PushChannels = new PushChannels(InstallId, httpClient);
-
-            LogPreviousCrashes();
+            return httpClient;
         }
 
         public void LogException(Exception e)

--- a/Com.Kumulos.Extension.nuspec
+++ b/Com.Kumulos.Extension.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
     <metadata>
         <id>Com.Kumulos.Extension</id>
-        <version>5.1.1.2</version>
+        <version>5.1.1.3</version>
         <title>Kumulos SDK iOS Extensions for Xamarin</title>
         <authors>Kumulos Ltd</authors>
         <owners>Kumulos Ltd</owners>

--- a/Com.Kumulos.nuspec
+++ b/Com.Kumulos.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
     <metadata>
         <id>Com.Kumulos</id>
-        <version>5.1.1.2</version>
+        <version>5.1.1.3</version>
         <title>Kumulos SDK for Xamarin</title>
         <authors>Kumulos Ltd</authors>
         <owners>Kumulos Ltd</owners>


### PR DESCRIPTION
### Description of Changes

The build service requires a larger response buffer as the returned data from backend tables can be larger than the standard 256k buffer.

### Breaking Changes

- None

### Release Checklist

Prepare:

- [x] Detail any breaking changes. Breaking changes require a new major version number
- [ ] Set Build target to Release -> Rebuild All
- [ ] Run `nuget pack` to create a bundle for nuget.org

Bump versions in:

- [x] `Com.Kumulos.nuspec`
- [x] `Com.Kumulos.Extension.nuspec`
- [x] `Com.Kumulos.Abstractions\Consts.cs`

Release:

- [ ] Squash and merge to master
- [ ] Delete branch once merged
- [ ] Create release/tag from master matching chosen version
- [ ] Upload the output Com.Kumulos.[version].nupkg to nuget.org
